### PR TITLE
styling: use legible tile labels

### DIFF
--- a/src/recipes.css
+++ b/src/recipes.css
@@ -63,18 +63,18 @@ image.chef.circular {
 }
 
 label.recipe.name {
-  background: alpha(@theme_base_color, .75);
+  background: @theme_base_color;
   color: @theme_fg_color;
   font-weight: bold;
-  font-size: 20px;
-  padding: 10px 20px 0px 20px;
+  font-size: 110%;
+  padding: 10px 10px 0;
 }
 
 label.recipe.author {
-  background: alpha(@theme_base_color, .75);
+  background: @theme_base_color;
   color: mix(@theme_base_color,@theme_fg_color,0.7);
-  font-size: 12px;
-  padding: 8px 20px 10px 20px;
+  font-size: 100%;
+  padding: 0 10px 10px;
 }
 
 @define-color diet_tag_bg #cc1212;


### PR DESCRIPTION
- bring theme closer to wireframes
- semi-opaque labels don't bring anything to the table